### PR TITLE
Fix leap year bug in LimpetIssueCertificate

### DIFF
--- a/code/LimpetApi/LimpetApi.cpp
+++ b/code/LimpetApi/LimpetApi.cpp
@@ -3058,10 +3058,17 @@ UINT32 LimpetIssueCertificate(
         certInfo.SignatureAlgorithm.pszObjId = &oidRsaSha256Rsa[0];
         certInfo.Issuer.cbData = caCert.get()->pCertInfo->Issuer.cbData;
         certInfo.Issuer.pbData = caCert.get()->pCertInfo->Issuer.pbData;
+        
+        // Set the NotBefore date to the current date and time
         GetSystemTime(&systemTime);
         SystemTimeToFileTime(&systemTime, &certInfo.NotBefore);
+        
+        // Set the NotAfter date 10 years later, accounting for leap day correctly
         systemTime.wYear += 10;
+        bool isLeapYear = systemTime.wYear % 4 == 0 && (systemTime.wYear % 100 != 0 || systemTime.wYear % 400 == 0);
+        systemTime.wDay = systemTime.wMonth == 2 && systemTime.wDay == 29 && !isLeapYear ? 28 : systemTime.wDay;
         SystemTimeToFileTime(&systemTime, &certInfo.NotAfter);
+
         certInfo.SubjectPublicKeyInfo = selfSignedCert.get()->pCertInfo->SubjectPublicKeyInfo;
 
         // Create the subject name


### PR DESCRIPTION
The `LimpetIssueCertificate` function was setting the certificate expiration date by adding 10 years, not correctly accounting for leap year.  In other words, if this function was called on `2020-02-29`, it would attempt to create a certificate with the expiration date of `2030-02-29`, which doesn't exist because 2030 is not a leap year.  (`CryptSignAndEncodeCertificate` will fail when passed such a date.)

This code corrects Feb 29th back to Feb 28th when the resulting year is not a leap year.